### PR TITLE
fontawesome changed to free version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -790,10 +790,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@fortawesome/fontawesome-pro": {
+    "@fortawesome/fontawesome-free": {
       "version": "5.9.0",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/fontawesome-pro-5.9.0.tgz",
-      "integrity": "sha512-vb7MJ0S+4FWZajv+iWKikG3QzX0oIAI+tYtlMBVwAyUmddESL/w5/2LCzbc81Vs4esGz0gr+bIem6BeMkIg+Mw=="
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.9.0.tgz",
+      "integrity": "sha512-g795BBEzM/Hq2SYNPm/NQTIp3IWd4eXSH0ds87Na2jnrAUFX3wkyZAI4Gwj9DOaWMuz2/01i8oWI7P7T/XLkhg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "webpackbar": "^3.2.0"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-pro": "^5.9.0",
+    "@fortawesome/fontawesome-free": "^5.9.0",
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0"

--- a/src/styles/vendor/font-awesome/_main.scss
+++ b/src/styles/vendor/font-awesome/_main.scss
@@ -2,21 +2,21 @@
 @import 'variables';
 
 // Core
-@import '~@fortawesome/fontawesome-pro/scss/variables';
-@import '~@fortawesome/fontawesome-pro/scss/mixins';
-@import '~@fortawesome/fontawesome-pro/scss/core';
-@import '~@fortawesome/fontawesome-pro/scss/larger';
-@import '~@fortawesome/fontawesome-pro/scss/fixed-width';
-@import '~@fortawesome/fontawesome-pro/scss/list';
-@import '~@fortawesome/fontawesome-pro/scss/bordered-pulled';
-@import '~@fortawesome/fontawesome-pro/scss/animated';
-@import '~@fortawesome/fontawesome-pro/scss/rotated-flipped';
-@import '~@fortawesome/fontawesome-pro/scss/stacked';
-@import '~@fortawesome/fontawesome-pro/scss/icons';
-@import '~@fortawesome/fontawesome-pro/scss/screen-reader';
+@import '~@fortawesome/fontawesome-free/scss/variables';
+@import '~@fortawesome/fontawesome-free/scss/mixins';
+@import '~@fortawesome/fontawesome-free/scss/core';
+@import '~@fortawesome/fontawesome-free/scss/larger';
+@import '~@fortawesome/fontawesome-free/scss/fixed-width';
+@import '~@fortawesome/fontawesome-free/scss/list';
+@import '~@fortawesome/fontawesome-free/scss/bordered-pulled';
+@import '~@fortawesome/fontawesome-free/scss/animated';
+@import '~@fortawesome/fontawesome-free/scss/rotated-flipped';
+@import '~@fortawesome/fontawesome-free/scss/stacked';
+@import '~@fortawesome/fontawesome-free/scss/icons';
+@import '~@fortawesome/fontawesome-free/scss/screen-reader';
 
 // Fonts
-// @import '~@fortawesome/fontawesome-pro/scss/light';
-// @import '~@fortawesome/fontawesome-pro/scss/regular';
-@import '~@fortawesome/fontawesome-pro/scss/solid';
-@import '~@fortawesome/fontawesome-pro/scss/brands';
+// @import '~@fortawesome/fontawesome-free/scss/light';
+// @import '~@fortawesome/fontawesome-free/scss/regular';
+@import '~@fortawesome/fontawesome-free/scss/solid';
+@import '~@fortawesome/fontawesome-free/scss/brands';

--- a/src/styles/vendor/font-awesome/_variables.scss
+++ b/src/styles/vendor/font-awesome/_variables.scss
@@ -1,1 +1,1 @@
-$fa-font-path: '~@fortawesome/fontawesome-pro/webfonts/';
+$fa-font-path: '~@fortawesome/fontawesome-free/webfonts/';


### PR DESCRIPTION
Due to the fact that fontawesome-pro is obsoleted, we need to use its free version: fontawesome-free